### PR TITLE
Development to Main 2026.06

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,8 @@ vtmedia-schema CHANGELOG
 
 ## CURRENT
 
+ - [schema-213](https://github.com/cjcodeproj/vtmedia-schema/issues/213) Album technical element
+ - [schema-139](https://github.com/cjcodeproj/vtmedia-schema/issues/139) Music: identify live performance locations and dates
  - [schema-211](https://github.com/cjcodeproj/vtmedia-schema/issues/211) Address record
  - [schema-212](https://github.com/cjcodeproj/vtmedia-schema/issues/212) Consolidate geo data types
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@ vtmedia-schema CHANGELOG
 
 ## CURRENT
 
+ - [schema-98](https://github.com/cjcodeproj/vtmedia-schema/issues/98) crew/music: child elements should not be mandated to follow a specific order
  - [schema-224](https://github.com/cjcodeproj/vtmedia-schema/issues/224) Add job role Assistant Art Director
  - [schema-220](https://github.com/cjcodeproj/vtmedia-schema/issues/220) Modify target audience
  - [schema-223](https://github.com/cjcodeproj/vtmedia-schema/issues/223) Support song lyrics

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@ vtmedia-schema CHANGELOG
 
 ## CURRENT
 
+ - [schema-220](https://github.com/cjcodeproj/vtmedia-schema/issues/220) Modify target audience
  - [schema-223](https://github.com/cjcodeproj/vtmedia-schema/issues/223) Support song lyrics
  - [schema-213](https://github.com/cjcodeproj/vtmedia-schema/issues/213) Album technical element
  - [schema-139](https://github.com/cjcodeproj/vtmedia-schema/issues/139) Music: identify live performance locations and dates

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,11 @@
 vtmedia-schema CHANGELOG
 =========================
 
+## CURRENT
+
+ - [schema-212](https://github.com/cjcodeproj/vtmedia-schema/issues/212) Consolidate geo data types
+
+ 
 ## RELEASE 2025.10
 
  - [schema-205](https://github.com/cjcodeproj/vtmedia-schema/issues/205) The Producers (not the movie)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,9 @@
 vtmedia-schema CHANGELOG
 =========================
 
-## CURRENT
+## RELEASE 2026.06
 
+ - [schema-225](https://github.com/cjcodeproj/vtmedia-schema/issues/225) Release 2026.06
  - [schema-98](https://github.com/cjcodeproj/vtmedia-schema/issues/98) crew/music: child elements should not be mandated to follow a specific order
  - [schema-224](https://github.com/cjcodeproj/vtmedia-schema/issues/224) Add job role Assistant Art Director
  - [schema-220](https://github.com/cjcodeproj/vtmedia-schema/issues/220) Modify target audience

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@ vtmedia-schema CHANGELOG
 
 ## CURRENT
 
+ - [schema-224](https://github.com/cjcodeproj/vtmedia-schema/issues/224) Add job role Assistant Art Director
  - [schema-220](https://github.com/cjcodeproj/vtmedia-schema/issues/220) Modify target audience
  - [schema-223](https://github.com/cjcodeproj/vtmedia-schema/issues/223) Support song lyrics
  - [schema-213](https://github.com/cjcodeproj/vtmedia-schema/issues/213) Album technical element

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@ vtmedia-schema CHANGELOG
 
 ## CURRENT
 
+ - [schema-223](https://github.com/cjcodeproj/vtmedia-schema/issues/223) Support song lyrics
  - [schema-213](https://github.com/cjcodeproj/vtmedia-schema/issues/213) Album technical element
  - [schema-139](https://github.com/cjcodeproj/vtmedia-schema/issues/139) Music: identify live performance locations and dates
  - [schema-211](https://github.com/cjcodeproj/vtmedia-schema/issues/211) Address record

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@ vtmedia-schema CHANGELOG
 
 ## CURRENT
 
+ - [schema-211](https://github.com/cjcodeproj/vtmedia-schema/issues/211) Address record
  - [schema-212](https://github.com/cjcodeproj/vtmedia-schema/issues/212) Consolidate geo data types
 
  

--- a/Makefile
+++ b/Makefile
@@ -45,6 +45,7 @@ FILES= $(SD)/media-schema.xsd \
 	$(SD)/vtm-mod-audio-elements-song.xsd \
 	$(SD)/vtm-mod-audio-technical.xsd \
 	$(SD)/vtm-mod-generic-crew-types.xsd \
+	$(SD)/vtm-mod-generic-geo-types.xsd \
 	$(SD)/vtm-mod-generic-pnouns-keywords.xsd \
 	$(SD)/vtm-mod-generic-story.xsd \
 	$(SD)/vtm-mod-generic-types.xsd \

--- a/Makefile
+++ b/Makefile
@@ -43,6 +43,7 @@ FILES= $(SD)/media-schema.xsd \
 	$(SD)/vtm-mod-audio-classification.xsd \
 	$(SD)/vtm-mod-audio-elements.xsd \
 	$(SD)/vtm-mod-audio-elements-song.xsd \
+	$(SD)/vtm-mod-audio-elements-song-composition.xsd \
 	$(SD)/vtm-mod-audio-technical.xsd \
 	$(SD)/vtm-mod-generic-crew-types.xsd \
 	$(SD)/vtm-mod-generic-geo-types.xsd \

--- a/examples/movies/c/coo/coco-2017-ultrahd.xml
+++ b/examples/movies/c/coo/coco-2017-ultrahd.xml
@@ -47,7 +47,7 @@
      <intendedAudience>
       <kids/>
       <kids/>
-      <families/>
+      <allAges/>
      </intendedAudience>
      <certifications>
       <certificate ref='51192'>

--- a/examples/movies/s/sus/the_sugarland_express-1974-bluray.xml
+++ b/examples/movies/s/sus/the_sugarland_express-1974-bluray.xml
@@ -60,7 +60,7 @@
       </subgenres>
      </genres>
      <intendedAudience>
-      <grownups/>
+      <adults/>
      </intendedAudience>
     </classification>
     <technical>

--- a/examples/music/artist/a/asl/asleep_at_the_wheel/live_at_billy_bobs_texas-2003-album.xml
+++ b/examples/music/artist/a/asl/asleep_at_the_wheel/live_at_billy_bobs_texas-2003-album.xml
@@ -15,6 +15,18 @@
   </genres>
   <livePerformance/>
  </classification>
+ <technical>
+  <liveRecording>
+   <where>
+    <name>Billy Bob's Texas</name>
+    <address>2520 Rodeo Plz</address>
+    <ci>Fort Worth</ci>
+    <st abbrv='TX'>Texas</st>
+    <cn>United States</cn>
+    <zip>76164</zip>
+   </where>
+  </liveRecording>
+ </technical>
  <elements>
   <song id='mam01'>
    <title>
@@ -31,7 +43,6 @@
     </composers>
    </catalog>
    <technical>
-    <liveRecording/>
     <runtime>
      <overall>PT3M38.38S</overall>
     </runtime>
@@ -49,7 +60,6 @@
     </composers>
    </catalog>
    <technical>
-    <liveRecording/>
     <runtime>
      <overall>PT3M27.52S</overall>
     </runtime>
@@ -73,7 +83,6 @@
     </composers>
    </catalog>
    <technical>
-    <liveRecording/>
     <runtime>
      <overall>PT3M6.20S</overall>
     </runtime>
@@ -91,7 +100,6 @@
     </composers>
    </catalog>
    <technical>
-    <liveRecording/>
     <runtime>
      <overall>PT2M47.65S</overall>
     </runtime>
@@ -112,7 +120,6 @@
     </composers>
    </catalog>
    <technical>
-    <liveRecording/>
     <runtime>
      <overall>PT3M6.60S</overall>
     </runtime>
@@ -133,7 +140,6 @@
     </composers>
    </catalog>
    <technical>
-    <liveRecording/>
     <runtime>
      <overall>PT3M39.78S</overall>
     </runtime>
@@ -151,7 +157,6 @@
     </composers>
    </catalog>
    <technical>
-    <liveRecording/>
     <runtime>
      <overall>PT3M56.59S</overall>
     </runtime>
@@ -172,7 +177,6 @@
     </composers>
    </catalog>
    <technical>
-    <liveRecording/>
     <runtime>
      <overall>PT3M25.31S</overall>
     </runtime>
@@ -193,7 +197,6 @@
     </composers>
    </catalog>
    <technical>
-    <liveRecording/>
     <runtime>
      <overall>PT3M11.89S</overall>
     </runtime>
@@ -214,7 +217,6 @@
     </composers>
    </catalog>
    <technical>
-    <liveRecording/>
     <runtime>
      <overall>PT3M52.04S</overall>
     </runtime>
@@ -232,7 +234,6 @@
     </composers>
    </catalog>
    <technical>
-    <liveRecording/>
     <runtime>
      <overall>PT2M56.17S</overall>
     </runtime>
@@ -250,7 +251,6 @@
     </composers>
    </catalog>
    <technical>
-    <liveRecording/>
     <runtime>
      <overall>PT3M56.56S</overall>
     </runtime>
@@ -268,7 +268,6 @@
     </composers>
    </catalog>
    <technical>
-    <liveRecording/>
     <runtime>
      <overall>PT3M53.76S</overall>
     </runtime>
@@ -286,7 +285,6 @@
     </composers>
    </catalog>
    <technical>
-    <liveRecording/>
     <runtime>
      <overall>PT4M27.66S</overall>
     </runtime>
@@ -304,7 +302,6 @@
     </composers>
    </catalog>
    <technical>
-    <liveRecording/>
     <runtime>
      <overall>PT4M20.11S</overall>
     </runtime>

--- a/examples/music/artist/c/coy/earl_thomas_conley/live_at_billy_bobs_texas-2005-album.xml
+++ b/examples/music/artist/c/coy/earl_thomas_conley/live_at_billy_bobs_texas-2005-album.xml
@@ -19,6 +19,18 @@
   </genres>
   <livePerformance/>
  </classification>
+ <technical>
+  <liveRecording>
+   <where>
+    <name>Billy Bob's Texas</name>
+    <address>2520 Rodeo Plz</address>
+    <ci>Fort Worth</ci>
+    <st abbrv='TX'>Texas</st>
+    <cn>United States</cn>
+    <zip>76164</zip>
+   </where>
+  </liveRecording>
+ </technical>
  <elements>
   <song id='sbr01'>
    <title>
@@ -35,7 +47,6 @@
     </composers>
    </catalog>
    <technical>
-    <liveRecording/>
     <runtime>
       <overall>PT4M7S</overall>
     </runtime>
@@ -56,7 +67,6 @@
     </composers>
    </catalog>
    <technical>
-    <liveRecording/>
     <runtime>
       <overall>PT3M4S</overall>
     </runtime>
@@ -77,7 +87,6 @@
     </composers>
    </catalog>
    <technical>
-    <liveRecording/>
     <runtime>
       <overall>PT3M26S</overall>
     </runtime>
@@ -98,7 +107,6 @@
     </composers>
    </catalog>
    <technical>
-    <liveRecording/>
     <runtime>
       <overall>PT3M25S</overall>
     </runtime>
@@ -119,7 +127,6 @@
     </composers>
    </catalog>
    <technical>
-    <liveRecording/>
     <runtime>
       <overall>PT2M53S</overall>
     </runtime>
@@ -140,7 +147,6 @@
     </composers>
    </catalog>
    <technical>
-    <liveRecording/>
     <runtime>
       <overall>PT3M0S</overall>
     </runtime>
@@ -161,7 +167,6 @@
     </composers>
    </catalog>
    <technical>
-    <liveRecording/>
     <runtime>
       <overall>PT4M12S</overall>
     </runtime>
@@ -182,7 +187,6 @@
     </composers>
    </catalog>
    <technical>
-    <liveRecording/>
     <runtime>
       <overall>PT3M12S</overall>
     </runtime>
@@ -203,7 +207,6 @@
     </composers>
    </catalog>
    <technical>
-    <liveRecording/>
     <runtime>
       <overall>PT3M41S</overall>
     </runtime>
@@ -224,7 +227,6 @@
     </composers>
    </catalog>
    <technical>
-    <liveRecording/>
     <runtime>
       <overall>PT3M4S</overall>
     </runtime>
@@ -248,7 +250,6 @@
     </composers>
    </catalog>
    <technical>
-    <liveRecording/>
     <runtime>
       <overall>PT2M53S</overall>
     </runtime>
@@ -269,7 +270,6 @@
     </composers>
    </catalog>
    <technical>
-    <liveRecording/>
     <runtime>
       <overall>PT4M1S</overall>
     </runtime>
@@ -287,7 +287,6 @@
     </composers>
    </catalog>
    <technical>
-    <liveRecording/>
     <runtime>
       <overall>PT2M42S</overall>
     </runtime>
@@ -308,7 +307,6 @@
     </composers>
    </catalog>
    <technical>
-    <liveRecording/>
     <runtime>
       <overall>PT3M38S</overall>
     </runtime>
@@ -329,7 +327,6 @@
     </composers>
    </catalog>
    <technical>
-    <liveRecording/>
     <runtime>
       <overall>PT2M47S</overall>
     </runtime>
@@ -350,7 +347,6 @@
     </composers>
    </catalog>
    <technical>
-    <liveRecording/>
     <runtime>
       <overall>PT3M18S</overall>
     </runtime>

--- a/examples/music/artist/r/riy/riders_in_the_sky/public_cowboy_1_a_centennial_salute_to_the_music_of_gene_autry-2007-album.xml
+++ b/examples/music/artist/r/riy/riders_in_the_sky/public_cowboy_1_a_centennial_salute_to_the_music_of_gene_autry-2007-album.xml
@@ -364,7 +364,8 @@
   </song>
   <song id='tlr01'>
    <title>
-    <main>The Last Roundup [Live At The Birchmere, Alexandria, VA / March 5-6, 1983]</main>
+    <main>The Last Roundup</main>
+    <!-- note: [Live At The Birchmere, Alexandria, VA / March 5-6, 1983]-->
    </title>
 <!-- EDIT FLAGS: detected_square_brackets possible_live_performance  -->
   <catalog>
@@ -378,7 +379,16 @@
    <bonusTrack/>
   </classification>
    <technical>
-    <liveRecording/>
+    <liveRecording>
+     <where>
+      <name>The Birchmere</name>
+      <address>3701 Mount Vernon Ave</address>
+      <ci>Alexandria</ci>
+      <st abbrv='VA'>Virginia</st>
+      <cn>United States</cn>
+      <zip>22305-2408</zip>
+     </where>
+    </liveRecording>
     <runtime>
       <overall>PT2M33.07S</overall>
     </runtime>

--- a/examples/music/artist/r/riy/riders_in_the_sky/public_cowboy_1_a_centennial_salute_to_the_music_of_gene_autry-2007-album.xml
+++ b/examples/music/artist/r/riy/riders_in_the_sky/public_cowboy_1_a_centennial_salute_to_the_music_of_gene_autry-2007-album.xml
@@ -388,6 +388,9 @@
       <cn>United States</cn>
       <zip>22305-2408</zip>
      </where>
+     <when>
+      <dates><from>1983-03-05</from><to>1983-03-06</to></dates>
+     </when>
     </liveRecording>
     <runtime>
       <overall>PT2M33.07S</overall>

--- a/examples/music/artist/w/war/jerry_jeff_walker/live_at_gruene_hall-1989-album.xml
+++ b/examples/music/artist/w/war/jerry_jeff_walker/live_at_gruene_hall-1989-album.xml
@@ -20,6 +20,18 @@
   </genres>
   <livePerformance/>
  </classification>
+ <technical>
+  <liveRecording>
+   <where>
+    <name>Gruene Hall</name>
+    <address>1281 Gruene Rd.</address>
+    <ci>New Braunfels</ci>
+    <st abbrv='TX'>Texas</st>
+    <cn>United States</cn>
+    <zip>78130</zip>
+   </where>
+  </liveRecording>
+ </technical>
  <elements>
   <song id='lml01'>
    <title>
@@ -35,7 +47,6 @@
     </composers>
    </catalog>
    <technical>
-    <liveRecording/>
     <runtime>
       <overall>PT3M40S</overall>
     </runtime>
@@ -55,7 +66,6 @@
     </composers>
    </catalog>
    <technical>
-    <liveRecording/>
     <runtime>
       <overall>PT4M19S</overall>
     </runtime>
@@ -75,7 +85,6 @@
     </composers>
    </catalog>
    <technical>
-    <liveRecording/>
     <runtime>
       <overall>PT3M48S</overall>
     </runtime>
@@ -96,7 +105,6 @@
     </composers>
    </catalog>
    <technical>
-    <liveRecording/>
     <runtime>
       <overall>PT4M18S</overall>
     </runtime>
@@ -116,7 +124,6 @@
     </composers>
    </catalog>
    <technical>
-    <liveRecording/>
     <runtime>
       <overall>PT6M1S</overall>
     </runtime>
@@ -136,7 +143,6 @@
     </composers>
    </catalog>
    <technical>
-    <liveRecording/>
     <runtime>
       <overall>PT5M22S</overall>
     </runtime>
@@ -156,7 +162,6 @@
     </composers>
    </catalog>
    <technical>
-    <liveRecording/>
     <runtime>
       <overall>PT3M34S</overall>
     </runtime>
@@ -176,7 +181,6 @@
     </composers>
    </catalog>
    <technical>
-    <liveRecording/>
     <runtime>
       <overall>PT4M41S</overall>
     </runtime>
@@ -197,7 +201,6 @@
     </composers>
    </catalog>
    <technical>
-    <liveRecording/>
     <runtime>
       <overall>PT4M49S</overall>
     </runtime>
@@ -218,7 +221,6 @@
     </composers>
    </catalog>
    <technical>
-    <liveRecording/>
     <runtime>
       <overall>PT4M37S</overall>
     </runtime>

--- a/schemas/vtm-content-audio.xsd
+++ b/schemas/vtm-content-audio.xsd
@@ -49,6 +49,7 @@
    <xs:element name='title' type='xs:string' minOccurs='1' maxOccurs='1'/>
    <xs:element name='catalog' type='AudioAlbumCatalogType' minOccurs='0' maxOccurs='1'/>
    <xs:element name='classification' type='AudioAlbumClassificationType' minOccurs='0' maxOccurs='1'/>
+   <xs:element name='technical' type='AudioAlbumTechnicalType' minOccurs='0' maxOccurs='1'/>
    <xs:element name='elements' type='AudioAlbumElementsType' minOccurs='1' maxOccurs='1'/>
   </xs:sequence>
   <xs:attributeGroup ref='ContentAttributeGroup'/>

--- a/schemas/vtm-mod-all-catalog.xsd
+++ b/schemas/vtm-mod-all-catalog.xsd
@@ -7,7 +7,7 @@
 
  <xs:annotation>
   <xs:documentation xml:lang='en-US'>
-    Copyright 2024, Chris Josephes
+    Copyright 2025, Chris Josephes
 
     This work is licensed under the Creative Commons Attribution-ShareAlike
     4.0 International License.
@@ -24,6 +24,7 @@
  <xs:import namespace='http://www.w3.org/1999/xlink' schemaLocation='xlink.xsd'/>
 
  <xs:include schemaLocation='vtm-mod-generic-types.xsd'/>
+ <xs:include schemaLocation='vtm-mod-generic-geo-types.xsd'/>
  <xs:include schemaLocation='vtm-mod-generic-crew-types.xsd'/>
 
  <xs:annotation>

--- a/schemas/vtm-mod-all-classification.xsd
+++ b/schemas/vtm-mod-all-classification.xsd
@@ -46,8 +46,8 @@
   <xs:choice>
    <xs:element name='kids' type='IntendedAudienceChoiceType'/>
    <xs:element name='teens' type='IntendedAudienceChoiceType'/>
-   <xs:element name='grownups' type='IntendedAudienceChoiceType'/>
-   <xs:element name='families' type='IntendedAudienceChoiceType'/>
+   <xs:element name='adults' type='IntendedAudienceChoiceType'/>
+   <xs:element name='allAges' type='IntendedAudienceChoiceType'/>
   </xs:choice>
  </xs:group>
 

--- a/schemas/vtm-mod-audio-elements-song-composition.xsd
+++ b/schemas/vtm-mod-audio-elements-song-composition.xsd
@@ -1,0 +1,42 @@
+<?xml version='1.0'?>
+
+<xs:schema xmlns:xs='http://www.w3.org/2001/XMLSchema' elementFormDefault='qualified'>
+
+ <xs:annotation>
+  <xs:documentation xml:lang='en-US'>
+    Copyright 2026, Chris Josephes
+
+    This work is licensed under the Creative Commons Attribution-ShareAlike
+    4.0 International License.
+
+    To view a copy of this license, visit
+    http://creativecommons.org/licenses/by-sa/4.0/ or
+    send a letter to
+    Creative Commons
+    PO Box 1866
+    Mountain View, CA 94042, USA.
+  </xs:documentation>
+ </xs:annotation>
+
+ <xs:annotation>
+  <xs:documentation xml:lang='en-US'>
+    Songs: Description information for song composition elements
+  </xs:documentation>
+ </xs:annotation>
+
+
+ <xs:complexType name='AudioSongCompositionRawLyrics'>
+  <xs:annotation>
+   <xs:documentation xml:lang='en-US'>
+     The lyrics of a song, in a barebones format,
+     suitable for song data that may have been imported
+     from a webpage or from ID3 metadata.
+   </xs:documentation>
+  </xs:annotation>
+  <xs:sequence>
+   <xs:element name='line' type='xs:string' minOccurs='1' maxOccurs='unbounded'/>
+  </xs:sequence>
+ </xs:complexType>
+
+</xs:schema>
+

--- a/schemas/vtm-mod-audio-elements-song.xsd
+++ b/schemas/vtm-mod-audio-elements-song.xsd
@@ -28,7 +28,7 @@
  <xs:include schemaLocation='vtm-mod-audio-catalog.xsd'/>
  <xs:include schemaLocation='vtm-mod-audio-classification.xsd'/>
  <xs:include schemaLocation='vtm-mod-audio-technical.xsd'/>
-
+ <xs:include schemaLocation='vtm-mod-audio-elements-song-composition.xsd'/>
 
  <xs:complexType name='AudioContentSongTitleType'>   <!-- song -->
   <xs:annotation>
@@ -73,6 +73,9 @@
     information to other works.
    </xs:documentation>
   </xs:annotation>
+  <xs:sequence>
+   <xs:element name='rawLyrics' type='AudioSongCompositionRawLyrics' minOccurs='0' maxOccurs='1'/>
+  </xs:sequence>
  </xs:complexType>
 
 

--- a/schemas/vtm-mod-audio-technical.xsd
+++ b/schemas/vtm-mod-audio-technical.xsd
@@ -18,6 +18,7 @@
   </xs:documentation>
  </xs:annotation>
 
+ <xs:include schemaLocation='vtm-mod-generic-geo-types.xsd'/>
 
  <xs:annotation>
   <xs:documentation xml:lang='en-US'>
@@ -37,6 +38,20 @@
   </xs:annotation>
  </xs:complexType>
 
+ <xs:complexType name='LiveAudioRecordingType'>
+  <xs:annotation>
+   <xs:documentation xml:lang='en-US'>
+    Generic empty element to identify a type of
+    recording.  The 3 elements, studio/live/demo will
+    actually be turned into different types in
+    the future.
+   </xs:documentation>
+  </xs:annotation>
+  <xs:sequence>
+   <xs:element name='where' type='FullAddressType' minOccurs='0' maxOccurs='1'/>
+  </xs:sequence>
+ </xs:complexType>
+
 
  <xs:group name='AudioRecordingGroup'>
   <xs:annotation>
@@ -48,7 +63,7 @@
   </xs:annotation>
   <xs:choice>
    <xs:element name='studioRecording' type='AudioRecordingType'/>
-   <xs:element name='liveRecording' type='AudioRecordingType'/>
+   <xs:element name='liveRecording' type='LiveAudioRecordingType'/>
    <xs:element name='demoRecording' type='AudioRecordingType'/>
   </xs:choice>
  </xs:group>
@@ -92,6 +107,17 @@
   </xs:sequence>
  </xs:complexType>
 
+ <xs:complexType name='AudioAlbumTechnicalType'>
+  <xs:annotation>
+   <xs:documentation xml:lang='en-US'>
+    A complex type for recording technical details of a song,
+    like the type of recording, the runtime, and the tempo.
+   </xs:documentation>
+  </xs:annotation>
+  <xs:sequence>
+   <xs:group ref='AudioRecordingGroup' minOccurs='1' maxOccurs='1'/>
+  </xs:sequence>
+ </xs:complexType>
 
  <xs:complexType name='AudioSongTechnicalType'>
   <xs:annotation>
@@ -101,7 +127,7 @@
    </xs:documentation>
   </xs:annotation>
   <xs:sequence>
-   <xs:group ref='AudioRecordingGroup' minOccurs='1' maxOccurs='1'/>
+   <xs:group ref='AudioRecordingGroup' minOccurs='0' maxOccurs='1'/>
    <xs:element name='runtime' type='AudioRuntimeType' minOccurs='1' maxOccurs='1'/>
    <xs:element name='tempo' type='AudioTempoType' minOccurs='0' maxOccurs='1'/>
   </xs:sequence>

--- a/schemas/vtm-mod-audio-technical.xsd
+++ b/schemas/vtm-mod-audio-technical.xsd
@@ -18,6 +18,7 @@
   </xs:documentation>
  </xs:annotation>
 
+ <xs:include schemaLocation='vtm-mod-generic-types.xsd'/>
  <xs:include schemaLocation='vtm-mod-generic-geo-types.xsd'/>
 
  <xs:annotation>
@@ -38,17 +39,39 @@
   </xs:annotation>
  </xs:complexType>
 
- <xs:complexType name='LiveAudioRecordingType'>
+ <xs:complexType name='RecordingDatesType'>
   <xs:annotation>
    <xs:documentation xml:lang='en-US'>
-    Generic empty element to identify a type of
-    recording.  The 3 elements, studio/live/demo will
-    actually be turned into different types in
-    the future.
+    Date of a live or studio recording.  In most cases,
+    the child elements will either be 'exact' or 'from'/'to'.
+   </xs:documentation>
+  </xs:annotation>
+  <xs:sequence>
+   <xs:element name='dates' type='VariableDateType' minOccurs='1' maxOccurs='1'/>
+  </xs:sequence>
+ </xs:complexType>
+
+ <xs:complexType name='StudioAudioRecordingType'>
+  <xs:annotation>
+   <xs:documentation xml:lang='en-US'>
+     Identifies a studio recording session.
    </xs:documentation>
   </xs:annotation>
   <xs:sequence>
    <xs:element name='where' type='FullAddressType' minOccurs='0' maxOccurs='1'/>
+   <xs:element name='when' type='RecordingDatesType' minOccurs='0' maxOccurs='1'/>
+  </xs:sequence>
+ </xs:complexType>
+
+ <xs:complexType name='LiveAudioRecordingType'>
+  <xs:annotation>
+   <xs:documentation xml:lang='en-US'>
+     Identifies a live recording sesssion.
+   </xs:documentation>
+  </xs:annotation>
+  <xs:sequence>
+   <xs:element name='where' type='FullAddressType' minOccurs='0' maxOccurs='1'/>
+   <xs:element name='when' type='RecordingDatesType' minOccurs='0' maxOccurs='1'/>
   </xs:sequence>
  </xs:complexType>
 
@@ -62,7 +85,7 @@
    </xs:documentation>
   </xs:annotation>
   <xs:choice>
-   <xs:element name='studioRecording' type='AudioRecordingType'/>
+   <xs:element name='studioRecording' type='StudioAudioRecordingType'/>
    <xs:element name='liveRecording' type='LiveAudioRecordingType'/>
    <xs:element name='demoRecording' type='AudioRecordingType'/>
   </xs:choice>

--- a/schemas/vtm-mod-generic-geo-types.xsd
+++ b/schemas/vtm-mod-generic-geo-types.xsd
@@ -54,4 +54,51 @@
   </xs:restriction>
  </xs:simpleType>
 
+ <xs:complexType name='FederatedStateType'>
+  <xs:annotation>
+   <xs:documentation xml:lang='en-US'>
+    A custom token type for a state or province.
+    including an attribute to support an abbreviation value.
+   </xs:documentation>
+  </xs:annotation>
+  <xs:simpleContent>
+   <xs:extension base='xs:token'>
+    <xs:attribute name='abbrv' type='xs:token' use='optional'/>
+   </xs:extension>
+  </xs:simpleContent>
+ </xs:complexType>
+
+ <xs:complexType name='CountryType'>
+  <xs:annotation>
+   <xs:documentation xml:lang='en-US'>
+    A data type for a country name, including
+    an attribute to support an abbreviation.
+   </xs:documentation>
+  </xs:annotation>
+  <xs:simpleContent>
+   <xs:extension base='xs:token'>
+    <xs:attribute name='abbrv' type='xs:token' use='optional'/>
+   </xs:extension>
+  </xs:simpleContent>
+ </xs:complexType>
+
+
+ <xs:complexType name='FullAddressType'>
+  <xs:annotation>
+   <xs:documentation xml:lang='en-US'>
+    A full address.
+    The value in this element should reflect a direct location
+    with enough information to pinpoint on a map.
+   </xs:documentation>
+  </xs:annotation>
+  <xs:sequence>
+   <xs:element name='name' type='xs:token' minOccurs='0' maxOccurs='1'/>
+   <xs:element name='address' type='xs:token' minOccurs='0' maxOccurs='1'/>
+   <xs:element name='ci' type='xs:token' minOccurs='1' maxOccurs='1'/>
+   <xs:element name='st' type='FederatedStateType' minOccurs='1' maxOccurs='1'/>
+   <xs:element name='cn' type='CountryType' minOccurs='1' maxOccurs='1'/>
+   <xs:element name='zip' type='xs:token' minOccurs='1' maxOccurs='1'/>
+  </xs:sequence>
+ </xs:complexType>
+
 </xs:schema>

--- a/schemas/vtm-mod-generic-geo-types.xsd
+++ b/schemas/vtm-mod-generic-geo-types.xsd
@@ -1,0 +1,57 @@
+<?xml version='1.0'?>
+
+<xs:schema xmlns:xs='http://www.w3.org/2001/XMLSchema' elementFormDefault='qualified'>
+
+ <xs:annotation>
+  <xs:documentation xml:lang='en-US'>
+    Copyright 2025, Chris Josephes
+
+    This work is licensed under the Creative Commons Attribution-ShareAlike
+    4.0 International License.
+
+    To view a copy of this license, visit
+    http://creativecommons.org/licenses/by-sa/4.0/ or
+    send a letter to
+    Creative Commons
+    PO Box 1866
+    Mountain View, CA 94042, USA.
+  </xs:documentation>
+ </xs:annotation>
+
+ <xs:annotation>
+  <xs:documentation xml:lang='en-US'>
+   <component>
+    <name>mediaschema/types/geo</name>
+   </component>
+  </xs:documentation>
+ </xs:annotation>
+
+
+ <xs:simpleType name='CountryCodeType'>
+  <xs:annotation>
+   <xs:documentation xml:lang='en-US'>
+    Country code type, with a restriction on length.
+    Can accept any value that is a standard ISO 3166-2, ISO 3166-3, or IDO 3166-1 value.
+   </xs:documentation>
+  </xs:annotation>
+  <xs:restriction base='xs:token'>
+   <xs:minLength value='2'/>
+   <xs:maxLength value='6'/>
+  </xs:restriction>
+ </xs:simpleType>
+
+ <xs:simpleType name='FederatedStateCodeType'>
+  <xs:annotation>
+   <xs:documentation xml:lang='en-US'>
+    Abbreviation type for a federated state (state, province, territory)
+    value.  Right now it's identical to CountryCodeType, but that could
+    change.
+   </xs:documentation>
+  </xs:annotation>
+  <xs:restriction base='xs:token'>
+   <xs:minLength value='2'/>
+   <xs:maxLength value='6'/>
+  </xs:restriction>
+ </xs:simpleType>
+
+</xs:schema>

--- a/schemas/vtm-mod-generic-types.xsd
+++ b/schemas/vtm-mod-generic-types.xsd
@@ -47,6 +47,7 @@
   </xs:restriction>
  </xs:simpleType>
 
+ <!--
  <xs:simpleType name='CountryCodeType'>
   <xs:annotation>
    <xs:documentation xml:lang='en-US'>
@@ -59,6 +60,7 @@
    <xs:maxLength value='6'/>
   </xs:restriction>
  </xs:simpleType>
+   -->
 
  <xs:simpleType name='CurrencyCodeType'>
   <xs:annotation>

--- a/schemas/vtm-mod-visual-crew.xsd
+++ b/schemas/vtm-mod-visual-crew.xsd
@@ -90,6 +90,7 @@
   </xs:annotation>
   <xs:choice>
    <xs:element name='artDirector' type='CrewNameType'/>
+   <xs:element name='assistArtDirector' type='CrewNameType'/>
    <xs:element name='supervisingArtDirector' type='CrewNameType'/>
    <xs:element name='seniorArtDirector' type='CrewNameType'/>
   </xs:choice>

--- a/schemas/vtm-mod-visual-crew.xsd
+++ b/schemas/vtm-mod-visual-crew.xsd
@@ -119,11 +119,27 @@
   </xs:sequence>
  </xs:complexType>
 
+ <xs:group name='MusicGroup'>
+  <xs:annotation>
+   <xs:documentation xml:lang='en-US'>
+    Job selection for the music department.
+   </xs:documentation>
+  </xs:annotation>
+  <xs:choice>
+   <xs:element name='composer' type='CrewPersonOrGroupType'/>
+   <xs:element name='conductor' type='CrewPersonOrGroupType'/>
+   <xs:element name='music' type='CrewPersonOrGroupType'/>
+  </xs:choice>
+ </xs:group>
+
  <xs:complexType name='MusicType'>
-  <xs:sequence minOccurs='1'>
-   <xs:element name='composer' type='CrewPersonOrGroupType' minOccurs='0' maxOccurs='unbounded'/>
-   <xs:element name='conductor' type='CrewNameType' minOccurs='0' maxOccurs='unbounded'/>
-   <xs:element name='music' type='CrewPersonOrGroupType' minOccurs='0' maxOccurs='unbounded'/>
+  <xs:annotation>
+   <xs:documentation xml:lang='en-US'>
+    Crew members from the music department
+   </xs:documentation>
+  </xs:annotation>
+  <xs:sequence>
+   <xs:group ref='MusicGroup' minOccurs='1' maxOccurs='unbounded'/>
   </xs:sequence>
  </xs:complexType>
 


### PR DESCRIPTION
Accumulated changes:

 - [schema-98](https://github.com/cjcodeproj/vtmedia-schema/issues/98) crew/music: child elements should not be mandated to follow a specific order
 - [schema-224](https://github.com/cjcodeproj/vtmedia-schema/issues/224) Add job role Assistant Art Director
 - [schema-220](https://github.com/cjcodeproj/vtmedia-schema/issues/220) Modify target audience
 - [schema-223](https://github.com/cjcodeproj/vtmedia-schema/issues/223) Support song lyrics
 - [schema-213](https://github.com/cjcodeproj/vtmedia-schema/issues/213) Album technical element
 - [schema-139](https://github.com/cjcodeproj/vtmedia-schema/issues/139) Music: identify live performance locations and dates
 - [schema-211](https://github.com/cjcodeproj/vtmedia-schema/issues/211) Address record
 - [schema-212](https://github.com/cjcodeproj/vtmedia-schema/issues/212) Consolidate geo data types


Release ticket: #225